### PR TITLE
Fix debian issues

### DIFF
--- a/debian/README.md
+++ b/debian/README.md
@@ -20,6 +20,13 @@ systemctl --user start ssh-tunnel.service
 # systemctl --user enable ssh-tunnel.service to auto run on startup
 ```
 
+If you want to start an ssh-tunnel to another server, make sure to add
+the server to `/etc/ssh-tunnel/ssh-tunnel.config` or `~/.ssh/config`, then run
+
+```bash
+systemctl --user start ssh-tunnel@the-name-of-your-server-here.service
+```
+
 ### Viewing logs
 
 If you ever want to view the logs of the reverse SSH service, you can do this

--- a/debian/ssh-tunnel.user.service
+++ b/debian/ssh-tunnel.user.service
@@ -15,7 +15,7 @@ StartLimitBurst=3
 
 Type=simple
 
-ExecStart=/usr/bin/ssh-tunnel --destination %I
+ExecStart=/usr/bin/ssh-tunnel --destination %i
 
 # try to restart and find an SSH connection
 # restarts until StartLimits are hit

--- a/debian/ssh-tunnel@.user.service
+++ b/debian/ssh-tunnel@.user.service
@@ -1,0 +1,1 @@
+./ssh-tunnel.user.service

--- a/ssh-tunnel
+++ b/ssh-tunnel
@@ -133,7 +133,11 @@ case $1 in
     exit 0
     ;;
 -d|--destination)
-    destination="$2"
+    if [ -z "$2" ]; then
+      echo "Warning: Ignoring empty --destination and keeping '$destination'." >&2
+    else
+      destination="$2"
+    fi
     shift
     ;;
 --check)


### PR DESCRIPTION
Fixes the SSH-tunnel code for debian.

Confirmed working on `pesky-python-pi`, which is an aarch64 raspberry pi running Ubuntu 22.04