### PR TITLE
docs: add mermaid diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ flowchart RL
 
     end
     P -.->|Reverse Tunnel| R
-    R -.->|Create Reverse Tunnel| serverPort
+    Host --->|Create Reverse Tunnel| serverPort
     P --->|SSH| R
 
     P2 -.->|Reverse Tunnel| R2


### PR DESCRIPTION
Adds a mermaid connection diagram to the README.md that attempts to explain how the reverse SSH connections works.

Closes #10 (although I'm not sure how well)