### PR TITLE
fix: revert SSH username to `ssh-tunnel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ in the home directory of the SSH tunnel user.
 
 Each file will have the name of a connected reverse SSH host, of format `<username>@<hostname>:<port>`.
 
-For example, assuming the reverse SSH tunnel is using the username `ssh-legion`,
+For example, assuming the reverse SSH tunnel is using the username `ssh-tunnel`,
 you can find all the connections by doing:
 
 ```console
-ubuntu@nqminds-iot-hub-ssh-control $ ls /home/ssh-legion/connections/
+ubuntu@nqminds-iot-hub-ssh-control $ ls /home/ssh-tunnel/connections/
 alexandru@dazzling-dream:48106
 ```
 
@@ -134,7 +134,7 @@ from your local PC, in your `~/.ssh/config` file, to just run `ssh dazzling-drea
 # The SSH Reverse Server
 Host nqminds-iot-hub-ssh-control
 	HostName ec2-34-251-158-148.eu-west-1.compute.amazonaws.com
-	User ubuntu
+	User ssh-tunnel
 
 Host dazzling-dream
 	HostName localhost

--- a/doc/ssh-tunnel-server.md
+++ b/doc/ssh-tunnel-server.md
@@ -2,24 +2,24 @@
 
 Recommended secure config for the Nquiringminds's SSH Tunnel Server.
 
-The following instructions creates a new user called `ssh-legion` on your server.
-A chroot jail is then created at `/home/ssh-legion/chroot-jail` containing
+The following instructions creates a new user called `ssh-tunnel` on your server.
+A chroot jail is then created at `/home/ssh-tunnel/chroot-jail` containing
 only the files required for the ssh-legion script to work.
 
 Finally, the `/etc/ssh/sshd_config` SSH config is modified so that ssh-ing
-into the `ssh-legion` will always lead into the Chroot Jail.
+into the `ssh-tunnel` will always lead into the Chroot Jail.
 
 ### Create Chroot Jail
 
 ```bash
-# creates /home/ssh-legion
-sudo adduser --system ssh-legion --shell /usr/bin/bash
-sudo -u ssh-legion mkdir --parents /home/ssh-legion/.ssh
-chroot="/home/ssh-legion/chroot-jail"
+# creates /home/ssh-tunnel
+sudo adduser --system ssh-tunnel --shell /usr/bin/bash
+sudo -u ssh-tunnel mkdir --parents /home/ssh-tunnel/.ssh
+chroot="/home/ssh-tunnel/chroot-jail"
 # The path to the chroot-jail must be owned by root
-sudo chown root:root /home/ssh-legion
-sudo -u ssh-legion touch /home/ssh-legion/.ssh/authorized_keys
-sudo -u ssh-legion chmod 600 /home/ssh-legion/.ssh/authorized_keys
+sudo chown root:root /home/ssh-tunnel
+sudo -u ssh-tunnel touch /home/ssh-tunnel/.ssh/authorized_keys
+sudo -u ssh-tunnel chmod 600 /home/ssh-tunnel/.ssh/authorized_keys
 
 function create_chroot_jail() {
     chroot_folder="$1"
@@ -29,11 +29,11 @@ function create_chroot_jail() {
         exit 1
     fi
 
-    sudo mkdir --parents "$chroot"/{dev,usr/bin,lib/x86_64-linux-gnu,lib64,home/ssh-legion/connections}
+    sudo mkdir --parents "$chroot"/{dev,usr/bin,lib/x86_64-linux-gnu,lib64,home/ssh-tunnel/connections}
     # chroot jail must be owned by root
     sudo chown --recursive root:root "$chroot"
     sudo chmod 0755 "$chroot"
-    sudo chown --recursive ssh-legion "$chroot"/home/ssh-legion/connections
+    sudo chown --recursive ssh-tunnel "$chroot"/home/ssh-tunnel/connections
 
     function copy_symlinks_to_file() {
         file="$1"
@@ -67,11 +67,11 @@ function create_chroot_jail() {
     sudo mknod "$chroot/dev/tty"  c 5 0
     sudo chmod 0666 "$chroot"/dev/{null,tty,zero}
     sudo chown root.tty "$chroot"/dev/tty
-    # sudo mount -t devtmpfs none /home/ssh-legion/chroot-jail/dev
+    # sudo mount -t devtmpfs none /home/ssh-tunnel/chroot-jail/dev
 }
 
 create_chroot_jail "$chroot"
-ln -s "$chroot"/home/ssh-legion/connections /home/ssh-legion/connections
+ln -s "$chroot"/home/ssh-tunnel/connections /home/ssh-tunnel/connections
 ```
 
 ### `/etc/ssh/sshd_config` config
@@ -81,6 +81,6 @@ Then, add the following file to your `/etc/ssh/sshd_config` file:
 ```conf
 # warning, this does not work from /etc/ssh/sshd_config/*.conf
 # in OpenSSH <= 8.4, see https://bugzilla.mindrot.org/show_bug.cgi?id=3122
-Match User ssh-legion
+Match User ssh-tunnel
     ChrootDirectory %h/chroot-jail
 ```

--- a/ssh-legion.config
+++ b/ssh-legion.config
@@ -2,7 +2,7 @@
 
 Host nqminds-iot-hub-ssh-control
         HostName ec2-34-251-158-148.eu-west-1.compute.amazonaws.com
-        User ssh-legion
+        User ssh-tunnel
         Port 22
         # Check connection every 15 seconds to see if connection is alive
         ServerAliveInterval 15


### PR DESCRIPTION
Our reverse SSH server is already setup to use `ssh-tunnel`, not `ssh-legion` as a username, and I'm a bit lazy to change it, so we might as well keep the old username.

(the script/package name is still ssh-legion)