### PR TITLE
build(deb): add missing dependency on openssl

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ssh-legion (0.1.1) UNRELEASED; urgency=low
+
+  * Add missing dependency on openssl 1.1.1
+
+ -- Alois Klink <alois@nquiringminds.com>  Tue, 26 Jul 2022 18:40:00 +0100
+
 ssh-legion (0.1.0) stable; urgency=low
 
   * Initial release.

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Package: ssh-legion
 Architecture: all
 Depends:
  openssh-client,
- bash (>= 4.3)
+ bash (>= 4.3),
+ openssl (>= 1.1.1)
 Description: Automatic reverse SSH tunnel for multiple IoT devices.
  Automatically sets up a reverse SSH tunnel to a remote host through a
  publically accesible Reverse SSH server.


### PR DESCRIPTION
OpenSSL >=1.1.1 is required for the openssl binary.
It is used to calculate SHA512-256 hashes.