### PR TITLE
chore: release v0.1.1 of ssh-legion

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-ssh-legion (0.1.1) UNRELEASED; urgency=low
+ssh-legion (0.1.1) stable; urgency=low
 
   * Add missing dependency on openssl 1.1.1
 
- -- Alois Klink <alois@nquiringminds.com>  Tue, 26 Jul 2022 18:40:00 +0100
+ -- Alois Klink <alois@nquiringminds.com>  Mon, 01 Aug 2022 16:00:00 +0100
 
 ssh-legion (0.1.0) stable; urgency=low
 


### PR DESCRIPTION
Changes
=======

* Add missing dependency on openssl 1.1.1

Seems to work in testing, so I might as well officially release it.