### PR TITLE
ci(publish): fix incorrect debian data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
                   url: context.payload.release.upload_url,
                   headers,
                   name: basename(filePath),
-                  file: await filePromise,
+                  data: await filePromise,
                 });
               } catch (error) {
                 // upload errors are usually since the file already exists


### PR DESCRIPTION
I'm not very smart! I never actually tested whether the `.deb`'s uploaded to GitHub were accurate.

It looks like by not passing a `data` param, the the data just became a JSON string of the file, so the size looked right, but it was useless data.

E.g., instead of the .deb file on the https://github.com/nqminds/edgesec/releases pages being real .debs, they were just strings of "file":{"type":"Buffer","data":[33,60,97,114,99,104,62,10,100,...

According to the official GitHub API docs, the actual field name is data: https://octokit.github.io/rest.js/v18#repos-upload-release-asset

Changes copied from https://github.com/nqminds/edgesec/pull/218