### PR TITLE
docs(server): add missing dependency on `grep`

### DIFF
--- a/doc/ssh-tunnel-server.md
+++ b/doc/ssh-tunnel-server.md
@@ -49,7 +49,7 @@ function create_chroot_jail() {
             sudo cp --verbose --parents --archive "$file" "$output_dir"
         done
     }
-    copy_binaries=(bash /bin/sh printf base64 gunzip gzip mkdir rm sleep date mv touch)
+    copy_binaries=(bash /bin/sh printf base64 grep gunzip gzip mkdir rm sleep date mv touch)
     for binary in $(ldd $(which "${copy_binaries[@]}")|grep -v dynamic|cut -d " " -f 3|sed 's/://'|sort|uniq)
     do
         copy_symlinks_to_file "$binary" "$chroot"


### PR DESCRIPTION
The SSH client runs the `grep` command on the server (see https://github.com/nqminds/ssh-legion/blob/15ab4a3cd12a5928750075ff0b7e0ce25bb063fd/ssh-legion#L68), so we need to setup `grep` on the server.

This bug was not noticed earlier since the grep command was in an `if` statement.