### PR TITLE
Refactor the `ssh-tunnel` code into it's own function

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -76,10 +76,10 @@ function ssh-legion() {
 }
 
 function join-array() {
-  local delimiter="${1-}" array="${2-}"
-  if shift 2; then
-    printf %s "$array" "${@/#/$delimiter}"
-  fi
+  local delimiter="$1"
+  local first_array_val="$2"
+  shift 2
+  printf %s "$first_array_val" "${@/#/$delimiter}"
 }
 
 function ssh-tunnel() {

--- a/ssh-legion
+++ b/ssh-legion
@@ -108,7 +108,7 @@ EOF
     "mkdir -p ~/connections"
     "FNAME=${FNAME@Q}" # FNAME is loaded from create-tunnel!
     "SALTED_MACHINE_ID=${SALTED_MACHINE_ID@Q}"
-    'if [ -f ~/connections/"${FNAME}" && ! grep "Machine ID: ${SALTED_MACHINE_ID}" < ~/connections/"${FNAME}"]; then \
+    'if [ -f ~/connections/"${FNAME}" ] && ! grep "Machine ID: ${SALTED_MACHINE_ID}" < ~/connections/"${FNAME}"; then \
     FNAME="${FNAME}+${SALTED_MACHINE_ID}"; fi'
     "echo -n ${COMPRESSED_INFO@Q} | base64 -d | gunzip > ~/connections/\${FNAME}"
     'rm -f ~/connections/"${FNAME}+disconnected"'

--- a/ssh-legion
+++ b/ssh-legion
@@ -75,6 +75,19 @@ function ssh-legion() {
   done
 }
 
+# Joins an array by the given delimiter
+#
+# ```bash
+# array=(a b c)
+# csv="$(join-array ',' "${array[@]}")"
+# echo "$csv" # prints 'a,b,c'
+# ```
+#
+# Args:
+#   - delimiter The delimiter, can be multiple chars
+#   - ...array The arra The array
+#
+# Adapted from Nicholas Sushkin (trivial/CC BY-SA 4.0) https://stackoverflow.com/a/17841619/10149169
 function join-array() {
   local delimiter="$1"
   local first_array_val="$2"
@@ -82,12 +95,25 @@ function join-array() {
   printf %s "$first_array_val" "${@/#/$delimiter}"
 }
 
+# Creates the SSH Tunnel to the server
+#
+# If the ssh-tunnel ever outputs `"Error: remote port forwarding failed for listen port"`,
+# then this function returns with `EX_UNAVAILABLE`.
+# If this happens, you should try creating the SSH tunnel again with a different port.
+#
+# Otherwise, it returns with `0` (success), even the error is becasue ssh failed for some other reason
+#
+# Args:
+#   - PORT The server port to tunnel to this device.
+#   - HOST_PORT The port on this device to tunnel to.
+#   - DESTINATION The server name in your ssh config.
 function ssh-tunnel() {
   local PORT="$1"
   local HOST_PORT="$2"
   local DESTINATION="$3"
 
   # this data will be stored in the ~/connections/... file on the reverse SSH server
+  # this data will only be updated when the tunnel restarts (so might be weeks)
   local INFO
   INFO="$(
     cat << EOF
@@ -101,6 +127,7 @@ EOF
 
   FNAME="${MYNAME}:${PORT}"
 
+  # These commands will be combined with `\n` and run on the Reverse SSH server
   local SERVER_COMMANDS
   # shellcheck disable=SC2016
   SERVER_COMMANDS=(
@@ -112,7 +139,7 @@ EOF
     FNAME="${FNAME}+${SALTED_MACHINE_ID}"; fi'
     "echo -n ${COMPRESSED_INFO@Q} | base64 -d | gunzip > ~/connections/\${FNAME}"
     'rm -f ~/connections/"${FNAME}+disconnected"'
-    'sleep infinity&'
+    'sleep infinity&' # Run sleep forever in background until killed by trap
     'SLEEP_PID="$!"'
     'on_disconnect() {
       mv ~/connections/"${FNAME}" ~/connections/"${FNAME}+disconnected"
@@ -121,7 +148,7 @@ EOF
       kill -SIGINT "$SLEEP_PID"
     }'
     'trap "on_disconnect ${SLEEP_PID}" EXIT'
-    'wait "${SLEEP_PID}"'
+    'wait "${SLEEP_PID}"' # Keep SSH active until sleep command or shell is killed
     # shellcheck enable=SC2016
   )
   server_commands_joined="$(join-array $'\n' "${SERVER_COMMANDS[@]}")"
@@ -131,7 +158,6 @@ EOF
   # putting localhost:${PORT} means the port is only accessible from localhost.
   # putting *:${PORT}, means the port is accessible from all interfaces, ie
   # going www.server.com:8080 will connect to the client:22
-
   ssh_options=(
     # description of ssh flags at https://manpages.ubuntu.com/manpages/jammy/man1/ssh.1.html
     "-tt" # force tty (so that `trap` works properly to monitor the tunnel)

--- a/ssh-legion
+++ b/ssh-legion
@@ -5,6 +5,10 @@
 reset='\033[0m'       # Text Reset
 cyan='\033[0;36m'         # Cyan
 
+# taken from sysexits.h
+# Used as a return code for when ssh-tunnel fails because the port is in use
+EX_UNAVAILABLE='69'
+
 # Adds SSH options to the given array.
 function ssh-global-options() {
   # Bash 4.3+ nameref https://www.gnu.org/software/bash/manual/html_node/Shell-Parameters.html
@@ -42,6 +46,86 @@ function ssh-legion() {
   SALTED_MACHINE_ID=${SALTED_MACHINE_ID//"+"/"-"}
   MYNAME="$(id -u -n)@$(uname -n)"
 
+  echo -e "${cyan}Info: Creating tunnel to ${destination}, use CTRL+C to cancel.${reset}" >&2
+
+
+  # used on purpose to send FNAME to the remote side
+  # shellcheck disable=SC2029
+
+  while true; do
+    if ! ssh-tunnel "$PORT" "$host_port" "$destination"; then
+      # RemotePortForwarding Failed!
+      # Port already in use
+      # Try using random ports until one works.
+
+      # we want a port between 1024 and 65535, range of 64511 numbers
+      R=$((RANDOM%64511))
+      # our random port
+      PORT=$((R+1024))
+      # make sure the PORT isn't in the list of IANA registered ports
+      while grep "${PORT}/tcp" /etc/services; do
+        # find a new random port
+        R=$((RANDOM%64511)); PORT=$((R+1024))
+      done
+    else
+      # ssh closed for some other reason, try again in a second
+      true
+    fi
+    sleep 1
+  done
+}
+
+function join-array() {
+  local delimiter="${1-}" array="${2-}"
+  if shift 2; then
+    printf %s "$array" "${@/#/$delimiter}"
+  fi
+}
+
+function ssh-tunnel() {
+  local PORT="$1"
+  local HOST_PORT="$2"
+  local DESTINATION="$3"
+
+  # this data will be stored in the ~/connections/... file on the reverse SSH server
+  local INFO
+  INFO="$(
+    cat << EOF
+${MYNAME} tunneled to localhost:${PORT} on $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+Salted Machine ID: ${SALTED_MACHINE_ID}
+${MYNAME}:~$ ip a \n $(ip a)
+EOF
+  )"
+  local COMPRESSED_INFO
+  COMPRESSED_INFO="$(echo -n "$INFO" | gzip | base64 -w0)"
+
+  FNAME="${MYNAME}:${PORT}"
+
+  local SERVER_COMMANDS
+  # shellcheck disable=SC2016
+  SERVER_COMMANDS=(
+    "set -e" # error if any command fails
+    "mkdir -p ~/connections"
+    "FNAME=${FNAME@Q}" # FNAME is loaded from create-tunnel!
+    "SALTED_MACHINE_ID=${SALTED_MACHINE_ID@Q}"
+    'if [ -f ~/connections/"${FNAME}" && ! grep "Machine ID: ${SALTED_MACHINE_ID}" < ~/connections/"${FNAME}"]; then \
+    FNAME="${FNAME}+${SALTED_MACHINE_ID}"; fi'
+    "echo -n ${COMPRESSED_INFO@Q} | base64 -d | gunzip > ~/connections/\${FNAME}"
+    'rm -f ~/connections/"${FNAME}+disconnected"'
+    'sleep infinity&'
+    'SLEEP_PID="$!"'
+    'on_disconnect() {
+      mv ~/connections/"${FNAME}" ~/connections/"${FNAME}+disconnected"
+      echo "Disconnected at $(date -u "+%Y-%m-%dT%H:%M:%SZ")" >> ~/connections/"${FNAME}+disconnected"
+      local SLEEP_PID="$1"
+      kill -SIGINT "$SLEEP_PID"
+    }'
+    'trap "on_disconnect ${SLEEP_PID}" EXIT'
+    'wait "${SLEEP_PID}"'
+    # shellcheck enable=SC2016
+  )
+  server_commands_joined="$(join-array $'\n' "${SERVER_COMMANDS[@]}")"
+
   # keep on running ssh tunnel until we don't have a listen port failure
 
   # putting localhost:${PORT} means the port is only accessible from localhost.
@@ -51,53 +135,15 @@ function ssh-legion() {
   ssh_options=(
     # description of ssh flags at https://manpages.ubuntu.com/manpages/jammy/man1/ssh.1.html
     "-tt" # force tty (so that `trap` works properly to monitor the tunnel)
-    "-o" "RemoteForward=localhost:${PORT} localhost:${host_port}"
+    "-o" "RemoteForward=localhost:${PORT} localhost:${HOST_PORT}"
   )
   ssh-global-options ssh_options
 
-  echo -e "${cyan}Info: Creating tunnel to ${destination}, use CTRL+C to cancel.${reset}" >&2
-
-  # used on purpose to send FNAME to the remote side
   # shellcheck disable=SC2029
-
-  while FNAME="${MYNAME}:${PORT}" \
-    && ssh "${ssh_options[@]}" "${destination}" \
-    "mkdir -p ~/connections \
-    && FNAME=$(printf '%q' "${FNAME}") \
-    && if [ -f ~/connections/\${FNAME} \
-        && ! grep \"Machine ID: ${SALTED_MACHINE_ID}\" < ~/connections/\${FNAME}]; then \
-      FNAME=${FNAME}+${SALTED_MACHINE_ID}; fi \
-    && echo $( \
-        DATA="${MYNAME} tunneled to localhost:${PORT} on $(date -u +'%Y-%m-%dT%H:%M:%SZ')"; \
-        DATA="${DATA}\nSalted Machine ID: ${SALTED_MACHINE_ID}"; \
-        IP_A_DATA="${MYNAME}:~$ ip a \n $(ip a) \n"; \
-        printf "%s\n%s" "${DATA}" "${IP_A_DATA}" | gzip | base64 -w0 \
-      ) \
-      | base64 -d | gunzip > ~/connections/\${FNAME} \
-    && rm -f ~/connections/\${FNAME}+disconnected \
-    && eval 'sleep infinity&' \
-    && eval 'echo \\\$1' | read SLEEP_PID \
-    && trap \"mv ~/connections/\${FNAME} \
-      ~/connections/\${FNAME}+disconnected\
-      && eval 'echo Disconnected at \\\$(date -u +'%Y-%m-%dT%H:%M:%SZ')'\
-        >> ~/connections/\${FNAME}+disconnected\
-      && kill -SIGINT \\\${SLEEP_PID} \" EXIT \
-    && wait" \
-  |& grep "Error: remote port forwarding failed for listen port"; do
-    # RemotePortForwarding Failed!
-    # Port already in use
-    # Try using random ports until one works.
-
-    # we want a port between 1024 and 65535, range of 64511 numbers
-    R=$((RANDOM%64511))
-    # our random port
-    PORT=$((R+1024))
-    # make sure the PORT isn't in the list of IANA registered ports
-    while grep "${PORT}/tcp" /etc/services; do
-      # find a new random port
-      R=$((RANDOM%64511)); PORT=$((R+1024))
-    done
-  done
+  if ssh "${ssh_options[@]}" "${DESTINATION}" "$server_commands_joined" 2>&1 >/dev/null | tee /dev/stderr | grep -q "Error: remote port forwarding failed for listen port"; then
+    # we need to change the port
+    return "$EX_UNAVAILABLE"
+  fi
 }
 
 function view-key() {


### PR DESCRIPTION
Refactors the `ssh-tunnel` code into it's own function.

We also use better bash quoting to run the server commands and the info commands.

This allowed us to catch a few bugs in the `ssh-tunnel` code (fixed in https://github.com/nqminds/ssh-legion/commit/80e1dc6fd87fd36fe5ac36a8cfe98cc55518c5fa):
  - where we had the `[]` brackets in the wrong place: [fix: fix info when same hostname but diff id](https://github.com/nqminds/ssh-legion/commit/80e1dc6fd87fd36fe5ac36a8cfe98cc55518c5fa)
  - https://github.com/nqminds/ssh-legion/pull/45.

Another change in behaviour is that the stderr of the ssh command is now piped both to `/dev/stderr` and to `grep`, so it should hopefully be logged too. Ideally we'd want to log `/dev/stdout` too, but I haven't figured out how to do that in bash.

Seems to fix #44 

---

Hey @AshleySetter, this bash code is pretty complicated, but if there's anything here that's super unclear, let me know and I can add some comments.