### PR TITLE
fix: suppress `cat` error on missing machine-id

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -22,8 +22,10 @@ function ssh-check() {
 }
 
 function ssh-legion() {
-  MACHINE_ID=$(cat /var/lib/dbus/machine-id || true)
-  if [ -z "$MACHINE_ID" ]; then
+  if [ -f /var/lib/dbus/machine-id ]; then
+    MACHINE_ID=$(cat /var/lib/dbus/machine-id)
+  else
+    echo -e "${cyan}Info: No dbus machine-id found, creating one from mac addresses.${reset}"
     mac="$(cat /sys/class/net/*/address | head -1)"
     MACHINE_ID="$(( 0x"${mac//:/''}" ))"
   fi


### PR DESCRIPTION
OpenWRT doesn't come with a /var/lib/dbus/machine-id file by default, as that's a dbus component.

Currently, the SSH script handles this badly, as it results in a `cat: can't open '/var/lib/dbus/machine-id': No such file or directory` error being printed. If there's a `set -e`, this will also cause the script to fail.