### PR TITLE
fix: seed RANDOM number generator with machine id

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -92,13 +92,11 @@ function ssh-legion() {
       # Try using random ports until one works.
 
       # we want a port between 1024 and 65535, range of 64511 numbers
-      R=$((RANDOM%64511))
-      # our random port
-      PORT=$((R+1024))
+      PORT=$((RANDOM % 64511 + 1024))
       # make sure the PORT isn't in the list of IANA registered ports
       while grep "${PORT}/tcp" /etc/services; do
         # find a new random port
-        R=$((RANDOM%64511)); PORT=$((R+1024))
+        PORT=$((RANDOM % 64511 + 1024))
       done
     elif [ "${RETRY_ON_SUCCESS_EXIT}" -eq 1 ]; then
       # ssh closed for some other reason, try again in a second

--- a/ssh-legion
+++ b/ssh-legion
@@ -80,6 +80,10 @@ function ssh-legion() {
 
   log-info "Creating tunnel to ${destination}, use CTRL+C to cancel."
 
+  # seed bash's random number generator with the initial port
+  # this means that ssh-legion will always try to use the same ports
+  RANDOM="$PORT"
+
   while true; do
     if ! ssh-tunnel "$PORT" "$host_port" "$destination" "$CONNECTION_TIME"; then
       # RemotePortForwarding Failed!

--- a/ssh-legion
+++ b/ssh-legion
@@ -80,9 +80,6 @@ function ssh-legion() {
 
   log-info "Creating tunnel to ${destination}, use CTRL+C to cancel."
 
-  # used on purpose to send FNAME to the remote side
-  # shellcheck disable=SC2029
-
   while true; do
     if ! ssh-tunnel "$PORT" "$host_port" "$destination" "$CONNECTION_TIME"; then
       # RemotePortForwarding Failed!


### PR DESCRIPTION
Seeds bash's random number generator with the initial port, which is generated from the consistent /etc/machine-id file. This means that ssh-legion will always try to use the same ports.

Previously, flakey SSH connections would cause a bunch of random ports to be used, so over time, we'd have hundreds of `alex@computer:<RANDOM_PORT>+disconnected` files on our server.

This change means we should only have a few (e.g. 1 to 3), since if they have the same port, the old files will be overwritten.
  
- [refactor: simplify random port generation](https://github.com/nqminds/ssh-legion/commit/c9e64379c4c900c54792c71f0ab8301a68161658)
  Instead of creating two separate variables for the `%` (modulus) and `+` (addition) steps, we may as well combine them into a single statement.