### PR TITLE
fix: close child processes on SIGTERM/SIGINT

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -317,13 +317,26 @@ if [ "$view_key" -ne 0 ]; then
   view-key
 fi
 
-if [ "$check" -ne 0 ]; then
-  ssh-check
-  exit "$?"
-fi
+function main() {
+  if [ "$check" -ne 0 ]; then
+    ssh-check
+    exit "$?"
+  fi
 
-ssh-legion
+  ssh-legion
 
-echo 2>&1 "$(basename "$0") --destination ${destination} failed"
-# always return failure since ssh-legion should never end
-exit 1
+  echo 2>&1 "$(basename "$0") --destination ${destination} failed"
+  # always return failure since ssh-legion should never end
+  exit 1
+}
+
+# On signal, removes trap for signal to all processes in this process group
+# This is needed for older init systems (e.g. openwrt) to correctly close `ssh`
+# when running `/etc/init.rc/... stop`
+trap "log-info 'Caught SIGTERM, exiting...' && trap - SIGTERM && kill -TERM -- 0" SIGTERM
+trap "log-info 'Caught SIGINT, exiting...' && trap - SIGINT && kill -INT -- 0" SIGINT
+
+# Run the main script in the background
+# Otherwise our `trap`s only get called once the ssh-tunnel script fails
+main &
+wait "$!"

--- a/ssh-legion
+++ b/ssh-legion
@@ -330,13 +330,16 @@ function main() {
   exit 1
 }
 
-# On signal, removes trap for signal to all processes in this process group
-# This is needed for older init systems (e.g. openwrt) to correctly close `ssh`
-# when running `/etc/init.rc/... stop`
-trap "log-info 'Caught SIGTERM, exiting...' && trap - SIGTERM && kill -TERM -- 0" SIGTERM
-trap "log-info 'Caught SIGINT, exiting...' && trap - SIGINT && kill -INT -- 0" SIGINT
-
 # Run the main script in the background
 # Otherwise our `trap`s only get called once the ssh-tunnel script fails
 main &
-wait "$!"
+
+main_pid="$!"
+
+# On signal, removes trap for signal to all processes in this process group
+# This is needed for older init systems (e.g. openwrt) to correctly close `ssh`
+# when running `/etc/init.rc/... stop`
+trap 'log-info "Caught SIGTERM, exiting..." && trap - SIGTERM && kill -TERM -- $(ps -o pid= --ppid "$main_pid") "$main_pid"' SIGTERM
+trap 'log-info "Caught SIGINT, exiting..." && trap - SIGINT && kill -INT -- $(ps -o pid= --ppid "$main_pid") "$main_pid"' SIGINT
+
+wait "$main_pid"


### PR DESCRIPTION
When ssh-legion catches a SIGTERM or SIGINT, it will send that signal to all child processes. This is so that the ssh subprocess is closed properly.

Older init systems like OpenWRT's `/etc/init.d/rc` do not close subprocesses by default (they just send a SIGTERM to the main process), so this is required.

I'm pretty sure this fixes #39, but I'm still in the process of testing it!