### PR TITLE
fix: log ssh stdout/err to ssh-legion stdout/err

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -204,8 +204,14 @@ EOF
   )
   ssh-global-options ssh_options
 
-  # shellcheck disable=SC2029
-  if ssh "${ssh_options[@]}" "${DESTINATION}" "$server_commands_joined" 2>&1 >/dev/null | tee /dev/stderr | grep -q "Error: remote port forwarding failed for listen port"; then
+  # pipe stderr through grep to see if SSH fails
+  # also pipe stdout and stderr to ssh-legion's stdout/stderr for debugging
+  if (
+      # shellcheck disable=SC2029 # escape on server side
+      ssh "${ssh_options[@]}" "${DESTINATION}" "$server_commands_joined" 2>&1 1>&"$ssh_stdout" \
+      | tee /dev/fd/"$ssh_stderr" | grep -q "Error: remote port forwarding failed for listen port"
+    ) {ssh_stdout}>&1 {ssh_stderr}>&2
+  then
     # we need to change the port
     return "$EX_UNAVAILABLE"
   fi


### PR DESCRIPTION
Previously, the stdout of the ssh command called by ssh-legion wasn't going anywhere (/dev/null)

Now, this output is piped to both the necessary commands and ssh-legion's stdout/stderr.
This works by temporarily piping them to new file descriptors, before piping the new file descriptors back to stdout/stderr when the commands are done.

This also replaces directly opening /dev/stderr with piping to >&2, so this should also fix the `tee: /dev/stderr: No such device or address` error when using systemd-journald. (see https://unix.stackexchange.com/q/401372)

### Notes to reviewer

I'll be honest, I still don't understand the order of operations with pipe redirections in Bash, but this PR seems to work, so `¯\_(ツ)_/¯`

I also heard that you're supposed to close the file descriptors after opening them, but my testing seems to show that they closed themselves, and I couldn't figure out a good way to close them manually, so I'll just leave it how it is.