### PR TITLE
fix: use bash process substitution for stderr

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -209,7 +209,7 @@ EOF
   if (
       # shellcheck disable=SC2029 # escape on server side
       ssh "${ssh_options[@]}" "${DESTINATION}" "$server_commands_joined" 2>&1 1>&"$ssh_stdout" \
-      | tee /dev/fd/"$ssh_stderr" | grep -q "Error: remote port forwarding failed for listen port"
+      | tee >( cat 1>&"$ssh_stderr" ) | grep -q "Error: remote port forwarding failed for listen port"
     ) {ssh_stdout}>&1 {ssh_stderr}>&2
   then
     # we need to change the port


### PR DESCRIPTION
The `tee /dev/fd/"$ssh_stderr"` syntax we used earlier for redirecting stderr output does not work with systemd-journald, as systemd-journald pipes to a UNIX domain socket, not a normal file.

This causes the error: `tee: /dev/fd/11: No such device or address`

Instead, we can use [bash's process substitution][1] to easily create another file descriptor that wraps around the UNIX domain socket.

[1]: https://www.gnu.org/software/bash/manual/bash.html#Process-Substitution
Fixes: 482dbb87031791f61d285371711d7df4c9af32bc

### Notes for reviewer

My bad! I only tested PR #54 locally, I didn't go through with the entire build `.deb` -> SSH to other PC -> install `.deb` -> test `.deb` testing chain!