### PR TITLE
build(debian): bump minimum bash version to v4.4

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Package: ssh-legion
 Architecture: all
 Depends:
  openssh-client,
- bash (>= 4.3),
+ bash (>= 4.4),
  openssl (>= 1.1.1)
 Description: Automatic reverse SSH tunnel for multiple IoT devices.
  Automatically sets up a reverse SSH tunnel to a remote host through a


### PR DESCRIPTION
We use the [`"${my_var@Q}"` shell parameter expansion][1], in order to quote strings "in a format that can be reused as input", e.g.:

https://github.com/nqminds/ssh-legion/blob/a66c9789b1fc2c00e4be0193b25fe3a22ffc6c1c/ssh-legion#L173

This feature was only added in [Bash 4.4 (see NEWS 1.o)][2].

If we do need to support older versions of Bash, or other shells, we can replace this with `$(printf "%q" "$my_var")`, from the [GNU Coreutils `printf` command][3].

[1]: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html#Shell-Parameter-Expansion
[2]: https://lists.gnu.org/archive/html/info-gnu/2016-09/msg00012.html
[3]: https://manpages.ubuntu.com/manpages/jammy/en/man1/printf.1.html