### PR TITLE
fix: fix ssh-legion not closing `ssh` on SIGTERM

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -209,11 +209,11 @@ EOF
 
   # pipe stderr through grep to see if SSH fails
   # also pipe stdout and stderr to ssh-legion's stdout/stderr for debugging
-  if (
+  if {
       # shellcheck disable=SC2029 # escape on server side
       ssh "${ssh_options[@]}" "${DESTINATION}" "$server_commands_joined" 2>&1 1>&"$ssh_stdout" \
       | tee >( cat 1>&"$ssh_stderr" ) | grep -q "Error: remote port forwarding failed for listen port"
-    ) {ssh_stdout}>&1 {ssh_stderr}>&2
+    } {ssh_stdout}>&1 {ssh_stderr}>&2
   then
     # we need to change the port
     return "$EX_UNAVAILABLE"


### PR DESCRIPTION
The bug fixed by #51 was broken by #54.

Using `( cmd )` in bash runs `cmd` in a new Bash subprocess.
This meant that our bash traps were just killing the `()` subprocess, not the `cmd` inside of it.

However, using `{ cmd; }` in bash runs `cmd` in the same Bash process, fixing this issue.

See [Command Grouping][1] in the bash manual.

[1]: https://www.gnu.org/software/bash/manual/bash.html#Command-Grouping
Fixes: 89141510a0101436804d50ecbe3da6bdb6acde51

---

Side note, I'm going to see if I can write a simple test for this.
I thought it would be a waste of time to write automated tests for this, but this bug keeps on coming back up again like a zombie :zombie: