### PR TITLE
feat: load default port from `/etc/machine-id`

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -56,10 +56,12 @@ function ssh-legion() {
   local CONNECTION_TIME="${1-""}"
   local RETRY_ON_SUCCESS_EXIT="${2-"1"}"
 
-  if [ -f /var/lib/dbus/machine-id ]; then
+  if [ -f /etc/machine-id ]; then
+    MACHINE_ID="$(cat /etc/machine-id)"
+  elif [ -f /var/lib/dbus/machine-id ]; then
     MACHINE_ID=$(cat /var/lib/dbus/machine-id)
   else
-    log-info 'No dbus machine-id found, creating one from mac addresses.'
+    log-info 'No dbus machine-id or /etc/machine-id found, creating one from mac addresses.'
     mac="$(cat /sys/class/net/*/address | head -1)"
     MACHINE_ID="$(( 0x"${mac//:/''}" ))"
   fi


### PR DESCRIPTION
Some platforms have a `/etc/machine-id` file, but they don't have a `/var/lib/dbus/machine-id` file.

---

On OpenWRT, we can easily create a `/etc/machine-id`, but `/var/lib/dbus/machine-id` doesn't seem like it survives a reboot.