### PR TITLE
build(pre-commit): update shellcheck to v0.9.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     -   id: script-must-have-extension
     -   id: script-must-not-have-extension
 -   repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: v0.9.0.2
     hooks:
     -   id: shellcheck
 -   repo: https://github.com/executablebooks/mdformat


### PR DESCRIPTION
Updates the shellcheck `pre-commit` script to use v0.9.0 of shellcheck.

Shellcheck v0.9.0 contains the following changes: https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v090---2022-12-12