### PR TITLE
fix: fix bash file descriptor leak

### DIFF
--- a/ssh-legion
+++ b/ssh-legion
@@ -217,9 +217,13 @@ EOF
       | tee >( cat 1>&"$ssh_stderr" ) | grep -q "Error: remote port forwarding failed for listen port"
     } {ssh_stdout}>&1 {ssh_stderr}>&2
   then
+    # close temporary file descriptors
+    exec {ssh_stdout}<&- {ssh_stderr}<&-
     # we need to change the port
     return "$EX_UNAVAILABLE"
   fi
+  # close temporary file descriptors
+  exec {ssh_stdout}<&- {ssh_stderr}<&-
 }
 
 function view-key() {


### PR DESCRIPTION
Fix bash file descriptor leak by explicitly closing file descriptors.

According to [Edition 5.2, section 3.6 Redirections][1] of the GNU bash manual,

> If _{varname}_ is supplied, the redirection persists beyond the scope of the command, allowing the shell programmer to manage the file descriptor’s lifetime manually.

As we don't set the `varredir_close` shell option, this means that we need to manually close the file descriptors.

[1]: https://www.gnu.org/software/bash/manual/html_node/Redirections.html

Fixes: https://github.com/nqminds/ssh-legion/issues/69

---

~Tested locally on my PC, please don't merge until I've tested this on an OpenWRT device first.~

Tested manually on OpenWRT, and it seems to work :)